### PR TITLE
fix: Add setproctitle in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     url                  = 'https://github.com/gooofy/py-nltools',
     packages             = ['nltools'],
     install_requires     = [
-                            'num2words', 'py-marytts', 'py-picotts', 'py-espeak-ng', 'pocketsphinx', 'py-kaldi-asr', 'numpy', 'webrtcvad',
+                            'num2words', 'py-marytts', 'py-picotts', 'py-espeak-ng', 'pocketsphinx', 'py-kaldi-asr', 'numpy', 'webrtcvad', 'setproctitle'
                            ],
     classifiers          = [
                                'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
In [nltools/misc.py](https://github.com/gooofy/py-nltools/blob/84524e9154b2ac024439824901d1012ed9e653dc/nltools/misc.py#L45) `setproctitle` is imported, but it's missing in the list of required packages.