### PR TITLE
feature: Add misc.render_template()

### DIFF
--- a/nltools/misc.py
+++ b/nltools/misc.py
@@ -271,3 +271,42 @@ def message_popup (stdscr, title, msg):
 
     return swin
 
+def render_template(template_file, dst_file, **kwargs):
+    """Copy template and substitute template strings
+
+    File `template_file` is copied to `dst_file`. Then, each template variable
+    is replaced by a value. Template variables are of the form
+
+        {{val}}
+
+    Example:
+
+    Contents of template_file:
+
+        VAR1={{val1}}
+        VAR2={{val2}}
+        VAR3={{val3}}
+
+    render_template(template_file, output_file, val1="hello", val2="world")
+
+    Contents of output_file:
+
+        VAR1=hello
+        VAR2=world
+        VAR3={{val3}}
+
+    :param template_file: Path to the template file.
+    :param dst_file: Path to the destination file.
+    :param kwargs: Keys correspond to template variables.
+    :return:
+    """
+    with open(template_file) as f:
+        template_text = f.read()
+
+    dst_text = template_text
+
+    for key, value in kwargs.iteritems():
+        dst_text = dst_text .replace("{{" + key + "}}", value)
+
+    with open(dst_file, "wt") as f:
+        f.write(dst_text)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -18,12 +18,21 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+import shutil
+import tempfile
+import os.path
 import unittest
 import logging
 
 from nltools import misc
 
 class TestMisc (unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
 
     def test_load_config(self):
 
@@ -65,6 +74,35 @@ class TestMisc (unittest.TestCase):
 
         self.assertEqual(misc.limit_str('1234567890', 10), '1234567890')
         self.assertEqual(misc.limit_str('1234567890',  9), '123456...')
+
+    def test_render_template(self):
+        # given
+        template_text = """VAR1={{val1}}
+        VAR2={{val2}}
+        """
+
+        val1 = "v1"
+        val2 = "v2"
+
+        expected_text = """VAR1=%s
+        VAR2=%s
+        """ % (val1, val2)
+
+        src_path = os.path.join(str(self.test_dir), "src.txt")
+        dst_path = os.path.join(str(self.test_dir), "dst.txt")
+
+        with open(src_path, "wt") as f:
+            f.write(template_text)
+
+        # when
+        misc.render_template(src_path, dst_path, val1=val1, val2=val2)
+
+        # then
+        with open(dst_path) as f:
+            actual_text = f.read()
+
+        self.assertEqual(expected_text, actual_text)
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
I noticed that in [kaldi-path.sh](https://github.com/gooofy/speech/blob/bdc33c1f1054aa81dc123f8e9bfe953391d58526/data/src/speech/kaldi-path.sh) the value of the variable `KALDI_ROOT` is hard coded to `/apps/kaldi-cuda`. Wouldn't it be nicer if instead the variable was read from `.speechrc`? To that end I've implemented `misc.render_template()`. For example in [speech_kaldi_export.py](https://github.com/gooofy/speech/blob/bdc33c1f1054aa81dc123f8e9bfe953391d58526/speech_kaldi_export.py#L329) instead of

    misc.copy_file ('data/src/speech/kaldi-path.sh', '%s/path.sh' % work_dir)

you'd then have

    kaldi_root  = config.get("speech", "kaldi_root")
    ...
    misc.render_template('data/src/speech/kaldi-path.sh.template', '%s/path.sh' % work_dir, kaldi_root=kaldi_root)

With the content of  `kaldi-path.sh.template` being

```bash
export KALDI_ROOT={{kaldi_root}}
export LD_LIBRARY_PATH="$KALDI_ROOT/tools/openfst-1.3.4/lib:$KALDI_ROOT/src/lib:$LD_LIBRARY_PATH"
export PATH=$KALDI_ROOT/src/lmbin/:$KALDI_ROOT/../kaldi_lm/:$PWD/utils/:$KALDI_ROOT/src/bin:$KALDI_ROOT/tools/openfst/bin:$KALDI_ROOT/src/fstbin/:$KALDI_ROOT/src/gmmbin/:$KALDI_ROOT/src/featbin/:$KALDI_ROOT/src/lm/:$KALDI_ROOT/src/sgmmbin/:$KALDI_ROOT/src/sgmm2bin/:$KALDI_ROOT/src/fgmmbin/:$KALDI_ROOT/src/latbin/:$KALDI_ROOT/src/nnetbin:$KALDI_ROOT/src/nnet2bin/:$KALDI_ROOT/src/online2bin/:$KALDI_ROOT/src/ivectorbin/:$KALDI_ROOT/src/kwsbin:$KALDI_ROOT/src/nnet3bin:$KALDI_ROOT/src/chainbin:$PWD:$PATH
export LC_ALL=C
```