### PR TITLE
Fix bug with XSAMPA_normalization normalization

### DIFF
--- a/nltools/phonetics.py
+++ b/nltools/phonetics.py
@@ -199,7 +199,6 @@ IPA_vowels = set([
 
 XSAMPA_normalization = {
     ' ': None,
-    '~': None,
     '0': 'O',
     ',': None,
     }

--- a/tests/test_phonetics.py
+++ b/tests/test_phonetics.py
@@ -19,7 +19,7 @@
 
 import logging
 import unittest
-from nltools.phonetics import ipa2xsampa, ipa2mary, xsampa2xarpabet, xs2xa_table
+from nltools.phonetics import ipa2xsampa, ipa2mary, xsampa2xarpabet, xs2xa_table, xsampa2ipa
 
 class TestPhoneticAlphabets (unittest.TestCase):
 
@@ -83,6 +83,10 @@ class TestPhoneticAlphabets (unittest.TestCase):
         res = ipa2mary ("POIGNANT", u"pwaɲɑ̃")
         #print "res: %s" % res
         self.assertEqual (res, "pwaJA~")
+
+        res = xsampa2ipa(u"entrée A~ t R e", u"A~ t R e")
+        #print "res: %s" % res
+        self.assertEqual (res, u"ɑ̃tʁe")
 
     def test_xarpa(self):
 


### PR DESCRIPTION
XSAMPA_normalization is broken which seriously affects several sequitur-based IPA entries (especially in French).